### PR TITLE
Ignore git directory changes while watching

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,8 @@ services:
       watch:
         - action: rebuild
           path: ../microcosm
+          ignore:
+            - .git
 
   web:
     build:
@@ -88,6 +90,8 @@ services:
         - action: sync
           path: ../microweb
           target: /app
+          ignore:
+            - .git
 
 networks:
   micronet:


### PR DESCRIPTION
This reduces the amount of false positive changes detected, thus reduces the amount of unneeded rebuilds.
